### PR TITLE
Avoid triple calls on onEquip(player, item, slot) in Movementscripts.

### DIFF
--- a/compiler/src/player.cpp
+++ b/compiler/src/player.cpp
@@ -2240,8 +2240,9 @@ ReturnValue Player::queryAdd(int32_t index, const Thing& thing, uint32_t count, 
 			return RETURNVALUE_NOTENOUGHCAPACITY;
 		}
 
-		if (!g_moveEvents->onPlayerEquip(const_cast<Player*>(this), const_cast<Item*>(item), static_cast<slots_t>(index), true)) {
+		/*if (!g_moveEvents->onPlayerEquip(const_cast<Player*>(this), const_cast<Item*>(item), static_cast<slots_t>(index), true)) {
 			return RETURNVALUE_CANNOTBEDRESSED;
+		}*/
 		}
 	}
 	return ret;


### PR DESCRIPTION
for example, reading an additional attribute with speed when equipping will receive 3x more speed if done with movementscript.

you can test if you have this error and your server:

In movements.xml
<!-- Attributes items -->
 <movevent event="Equip" itemid="3554" slot="feet" script="equipment/attributes.lua"/>
 <movevent event="DeEquip" itemid="3554" slot="feet" script="equipment/attributes.lua"/>

In equipment/attributes.lua
function onEquip(player, item, slot)
 player:sendTextMessage(MESSAGE_STATUS_CONSOLE_RED, string.format("onEquip"))
    return true
end

function onDeEquip(player, item, slot)
 player:sendTextMessage(MESSAGE_STATUS_CONSOLE_RED, string.format("onDeEquip"))
    return true
end